### PR TITLE
fix: ie11 / edge Error: Object doesn't support property or method 'in…

### DIFF
--- a/projects/translate/src/lib/translate.service.ts
+++ b/projects/translate/src/lib/translate.service.ts
@@ -240,7 +240,7 @@ export class TranslateService {
       lang !== this.activeLang &&
       (this.supportedLangs &&
         this.supportedLangs.length > 0 &&
-        !this.supportedLangs.includes(lang))
+        !(this.supportedLangs.indexOf(lang) >= 0))
     );
   }
 


### PR DESCRIPTION
Small fix for ie11 / edge  Object doesn't support property or method 'includes'