### PR TITLE
attribute directive

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [2.3.0]
+
+### Added
+
+- Attribute directive support with extra translation scenarios and examples
+
 ## [2.0.0] - 2019-06-20
 
 ### Changed

--- a/README.md
+++ b/README.md
@@ -78,6 +78,9 @@ In the main application template, use the following snippet:
 - `<element [innerHTML]="'KEY' | translate"></element>`
 - `<element>{{ 'PROPERTY.PATH' | translate }}</element>`
 - `<element>{{ 'FORMAT' | translate:params }}</element>`
+- (2.3.0) `<element [translate]="'KEY'"></element>`
+- (2.3.0) `<element [translate]="'FORMAT'" [translateParams]="{ msg: hello }"></element>`
+- (2.3.0) `<element translate="KEY"></element>`
 
 ### Title Service
 

--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
     "ng": "ng",
     "start": "ng build translate && ng serve",
     "build": "ng build",
-    "test": "ng test translate",
+    "test": "ng test translate --code-coverage",
     "test:ci": "ng test translate --watch=false --code-coverage",
     "lint": "ng lint",
     "e2e": "ng e2e",

--- a/projects/translate/src/lib/translate.directive.spec.ts
+++ b/projects/translate/src/lib/translate.directive.spec.ts
@@ -1,0 +1,116 @@
+import { TestBed, ComponentFixture } from '@angular/core/testing';
+import { Component, DebugElement } from '@angular/core';
+import { TranslateDirective } from './translate.directive';
+import { By } from '@angular/platform-browser';
+import { TranslateService } from './translate.service';
+import { HttpClientModule } from '@angular/common/http';
+
+@Component({
+  template: `
+    <div id="case1" [translate]="message"></div>
+    <div id="case2" translate="key1"></div>
+    <div
+      id="case3"
+      [translate]="'formatted'"
+      [translateParams]="{ name: 'Bob' }"
+    ></div>
+    <div id="case4" [translate]></div>
+  `
+})
+class TestComponent {
+  message = 'message1';
+}
+
+describe('TranslateDirective', () => {
+  let fixture: ComponentFixture<TestComponent>;
+  // let elements: DebugElement[];
+  let translate: TranslateService;
+
+  beforeEach(() => {
+    TestBed.configureTestingModule({
+      imports: [HttpClientModule],
+      declarations: [TestComponent, TranslateDirective],
+      providers: [TranslateService]
+    });
+
+    translate = TestBed.get(TranslateService);
+
+    translate.use('en', {
+      message1: 'hello, world',
+      key1: 'hello, there',
+      formatted: 'hello, {name}'
+    });
+
+    translate.use('ua', {
+      message1: '[ua] hello, world',
+      key1: '[ua] hello, there',
+      formatted: '[ua] hello, {name}'
+    });
+
+    fixture = TestBed.createComponent(TestComponent);
+    fixture.detectChanges();
+  });
+
+  it('should have elements', () => {
+    const elements = fixture.debugElement.queryAll(
+      By.directive(TranslateDirective)
+    );
+    expect(elements.length).toBe(4);
+  });
+
+  it('should translate with property binding', () => {
+    const element = fixture.debugElement.query(By.css('#case1'));
+
+    expect(element).toBeDefined();
+    expect(element.nativeElement.innerText).toBe('hello, world');
+  });
+
+  it('should translate with plain attribute', () => {
+    const element = fixture.debugElement.query(By.css('#case2'));
+
+    expect(element).toBeDefined();
+    expect(element.nativeElement.innerText).toBe('hello, there');
+  });
+
+  it('should translate with the parameters', () => {
+    const element = fixture.debugElement.query(By.css('#case3'));
+
+    expect(element).toBeDefined();
+    expect(element.nativeElement.innerText).toBe('hello, Bob');
+  });
+
+  it('should update element on language change', done => {
+    const element = fixture.debugElement.query(By.css('#case1'));
+
+    expect(element).toBeDefined();
+    expect(element.nativeElement.innerText).toBe('hello, world');
+
+    translate.activeLang = 'ua';
+
+    fixture.detectChanges();
+    fixture.whenStable().then(() => {
+      expect(element.nativeElement.innerText).toBe('[ua] hello, world');
+      done();
+    });
+  });
+
+  it('should update element only when key provided', () => {
+    const element = fixture.debugElement.query(By.css('#case4'));
+
+    expect(element).toBeDefined();
+    expect(element.nativeElement.innerText).toBe('');
+  });
+
+  it('should update only when dom element present', () => {
+    spyOn(translate, 'get').and.stub();
+
+    const directive = new TranslateDirective(
+      <any>{ nativeElement: null },
+      translate
+    );
+    directive.key = 'key';
+    directive.ngOnInit();
+
+    expect(translate.get).not.toHaveBeenCalled();
+  });
+});

--- a/projects/translate/src/lib/translate.directive.spec.ts
+++ b/projects/translate/src/lib/translate.directive.spec.ts
@@ -23,7 +23,6 @@ class TestComponent {
 
 describe('TranslateDirective', () => {
   let fixture: ComponentFixture<TestComponent>;
-  // let elements: DebugElement[];
   let translate: TranslateService;
 
   beforeEach(() => {

--- a/projects/translate/src/lib/translate.directive.ts
+++ b/projects/translate/src/lib/translate.directive.ts
@@ -1,0 +1,46 @@
+import { Directive, ElementRef, OnInit, Input, OnDestroy } from '@angular/core';
+import { TranslateService } from './translate.service';
+import { Subject } from 'rxjs';
+import { takeUntil } from 'rxjs/operators';
+
+@Directive({
+  // tslint:disable-next-line: directive-selector
+  selector: '[translate]'
+})
+export class TranslateDirective implements OnInit, OnDestroy {
+  private onDestroy$ = new Subject<boolean>();
+
+  @Input('translate')
+  key = '';
+
+  @Input()
+  translateParams: any = null;
+
+  constructor(private el: ElementRef, private translate: TranslateService) {}
+
+  ngOnInit() {
+    this.updateElement();
+
+    this.translate.activeLangChanged
+      .pipe(takeUntil(this.onDestroy$))
+      .subscribe(() => this.updateElement());
+  }
+
+  private updateElement() {
+    if (this.key) {
+      const domElement: HTMLElement = this.el.nativeElement;
+
+      if (domElement) {
+        domElement.innerText = this.translate.get(
+          this.key,
+          this.translateParams
+        );
+      }
+    }
+  }
+
+  ngOnDestroy() {
+    this.onDestroy$.next(true);
+    this.onDestroy$.complete();
+  }
+}

--- a/projects/translate/src/lib/translate.module.ts
+++ b/projects/translate/src/lib/translate.module.ts
@@ -4,11 +4,12 @@ import { TranslateService, TRANSLATE_SETTINGS } from './translate.service';
 import { TranslatePipe } from './translate.pipe';
 import { TitleService } from './title.service';
 import { TranslateSettings } from './translate.settings';
+import { TranslateDirective } from './translate.directive';
 
 @NgModule({
   imports: [CommonModule],
-  declarations: [TranslatePipe],
-  exports: [TranslatePipe]
+  declarations: [TranslatePipe, TranslateDirective],
+  exports: [TranslatePipe, TranslateDirective]
 })
 export class TranslateModule {
   static forRoot(settings?: TranslateSettings): ModuleWithProviders {

--- a/src/app/translate-demo/translate-demo.component.html
+++ b/src/app/translate-demo/translate-demo.component.html
@@ -13,3 +13,21 @@
 </p>
 
 <p>Custom Pipe: {{ 'TITLE' | myTranslate }}</p>
+
+<p>
+  Attribute directive:
+  <span [translate]="'TITLE'"></span>
+</p>
+
+<p>
+  Attribute directive (plain):
+  <span translate="TITLE"></span>
+</p>
+
+<p>
+  Attribute directive with params:
+  <span
+    [translate]="'FORMATTED.HELLO_MESSAGE'"
+    [translateParams]="{ username: 'world' }"
+  ></span>
+</p>


### PR DESCRIPTION
Provide support for the attribute directive.
Fixes #90 

Examples:

```html
<span [translate]="'TITLE'"></span>
<span translate="TITLE"></span>
<span
    [translate]="'FORMATTED.HELLO_MESSAGE'"
    [translateParams]="{ username: 'world' }"
></span>
```